### PR TITLE
Refactor animation playback control logic

### DIFF
--- a/src/runtime/Lottie.vue
+++ b/src/runtime/Lottie.vue
@@ -267,18 +267,14 @@ const loadLottie = () => {
   lottieAnimation = Lottie.loadAnimation(lottieAnimationConfig);
 
   setTimeout(() => {
-    autoplay = props.autoplay;
-
-    if (props.playOnHover) {
+    // Respect pauseAnimation / playOnHover first
+    if (props.pauseAnimation || props.playOnHover) {
       lottieAnimation?.pause();
+    } else if (props.autoplay) {
+      lottieAnimation?.play();
     } else {
-      if (autoplay) {
-        lottieAnimation?.play();
-      } else {
-        lottieAnimation?.pause();
-      }
+      lottieAnimation?.pause();
     }
-
     /**
      * Emit an `onAnimationLoaded` event when the animation is loaded
      * This should help with times where you want to run functions on the ref of the element


### PR DESCRIPTION
While testing out the module, I discovered the `pause-animation` prop never actually paused the animation while playing. 
So if you simply pass `:pause-animation="true"` to the component, it doesn't do anything. 

Previously, autoplay true in the delayed block overrode the earlier pause. Ensuring pauseAnimation is checked inside the delayed block (or disabling autoplay) keeps it paused.

I replaced the setTimeout block to respect `pauseAnimation`, and removed the later duplicate pause block.