### PR TITLE
fix: add null guard after loadAnimation to resolve TS18047 errors

### DIFF
--- a/src/runtime/Lottie.vue
+++ b/src/runtime/Lottie.vue
@@ -266,6 +266,8 @@ const loadLottie = () => {
   // actually load the animation
   lottieAnimation = Lottie.loadAnimation(lottieAnimationConfig);
 
+  if (!lottieAnimation) return;
+
   setTimeout(() => {
     // Respect pauseAnimation / playOnHover first
     if (props.pauseAnimation || props.playOnHover) {


### PR DESCRIPTION
## Problem

\`Lottie.loadAnimation()\` can return \`null\`, but the return value is immediately used without a null check. This causes TypeScript (\`strict: true\`) to report 9 \`TS18047: 'lottieAnimation' is possibly 'null'\` errors in \`dist/runtime/Lottie.vue\`, which breaks \`nuxt typecheck\` for any project using this module.

## Fix

Add an early return after \`loadAnimation\` — if the animation didn't load, none of the subsequent calls should execute anyway.

\`\`\`diff
  lottieAnimation = Lottie.loadAnimation(lottieAnimationConfig);

+ if (!lottieAnimation) return;
+
  setTimeout(() => {
\`\`\`

This is a one-line fix with no runtime behaviour change in the happy path.

Closes #20