### PR TITLE
feat: add #fallback slot for SSR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Nuxt Lottie - Easily integrate Lottie animations into your Nuxt project.
 - 🗂️ Automatic Imports
 - 🎨 Nested Folder Support
 - 🛠️ Programmatic Control
+- 🖼️ SSR Fallback Slot
 - 💚 Nuxt 4 Ready
 
 ## Quick Setup
@@ -132,6 +133,20 @@ import HelloJSON from './hello.json'
 ```
 
 
+
+## SSR Fallback Slot
+
+Because Lottie animations are client-only, the component renders nothing on the server by default. You can pass a `#fallback` slot to show a static placeholder during SSR and before hydration — no `<ClientOnly>` wrapper needed.
+
+```vue
+<Lottie name="rocket">
+  <template #fallback>
+    <img src="/rocket-static.png" alt="rocket" />
+  </template>
+</Lottie>
+```
+
+The fallback is replaced by the animation once the client takes over. If no `#fallback` slot is provided, the behaviour is identical to before.
 
 ## Programmatic Control
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,6 +42,13 @@ export default defineNuxtModule<ModuleOptions>({
       mode: "client",
     });
 
+    addComponent({
+      name: `${options.componentName}`,
+      global: true,
+      filePath: resolve("./runtime/LottieFallback.vue"),
+      mode: "server",
+    });
+
     const logger = useLogger("nuxt-lottie");
 
     const isSSR = nuxt.options.ssr !== false;

--- a/src/runtime/LottieFallback.vue
+++ b/src/runtime/LottieFallback.vue
@@ -1,0 +1,3 @@
+<template>
+  <slot name="fallback" />
+</template>


### PR DESCRIPTION
## Summary

Adds native `#fallback` slot support to the `<Lottie>` component, so a static placeholder can be shown during SSR and before client-side hydration — without wrapping in `<ClientOnly>`.

## How it works

A minimal server-side stub component (`LottieFallback.vue`) is registered alongside the existing client-only component using the same component name but `mode: "server"`. This mirrors Nuxt's own `.client.vue` / `.server.vue` paired-component pattern.

- **Server / pre-hydration**: renders `<slot name="fallback" />`
- **After hydration**: the client component takes over and renders the animation

No changes to the existing `Lottie.vue` client component. Fully backward-compatible — when no `#fallback` slot is provided, the behaviour is identical to before.

## Usage

```vue
<Lottie name="spinner">
  <template #fallback>
    <StaticSpinnerIcon />
  </template>
</Lottie>
```

Closes #18