### PR TITLE
feat: add module-level default prop values via lottie.defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,11 @@ You can configure the module behavior in your `nuxt.config.ts` file:
 | lottieFolder       | String  | "/assets/lottie" | Customize the Lottie folder path where animations are stored                                                                   |
 | autoFolderCreation | Boolean | true             | Automatically create the lottie folder if it doesn't exist. You can disable for client-only apps or manual folder management          |
 | enableLogs         | Boolean | true             | Enable terminal logs from the module during development. Disable if you like silence.                                       |
-| defaults           | Object  | {}               | Set default prop values for every `<Lottie>` instance project-wide. Any prop listed in the Props table can be used as a key. Per-instance props always take priority. |
+| defaults           | Object  | {}               | Set default prop values for every `<Lottie>` instance project-wide. Use the component’s **camelCase** prop keys (e.g. `pauseAnimation`, `pauseOnHover`, `rendererSettings`). Per-instance props always take priority. |
 
 ### Component Defaults
 
-Use `lottie.defaults` to avoid repeating the same props on every `<Lottie>` usage. Any prop from the table below can be set as a key. Individual instances can still override them.
+Use `lottie.defaults` to avoid repeating the same props on every `<Lottie>` usage. Use camelCase keys matching the component props (not kebab-case). Individual instances can still override them.
 
 ```ts
 // nuxt.config.ts

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Nuxt Lottie - Easily integrate Lottie animations into your Nuxt project.
 - 🗂️ Automatic Imports
 - 🎨 Nested Folder Support
 - 🛠️ Programmatic Control
+- ⚙️ Module-level Default Props
 - 💚 Nuxt 4 Ready
 
 ## Quick Setup
@@ -54,7 +55,11 @@ export default defineNuxtConfig({
     componentName: 'Lottie', // Optional: Customize the component name
     lottieFolder: '/assets/lottie', // Optional: Customize the Lottie folder path
     autoFolderCreation: true, // Optional: Auto create lottie folder (default: true)
-    enableLogs: true // Optional: Enable console logs from module (default: true)
+    enableLogs: true, // Optional: Enable console logs from module (default: true)
+    defaults: { // Optional: Set default prop values for all <Lottie> instances
+      loop: false,
+      autoplay: false,
+    }
   }
 })
 ```
@@ -172,6 +177,32 @@ You can configure the module behavior in your `nuxt.config.ts` file:
 | lottieFolder       | String  | "/assets/lottie" | Customize the Lottie folder path where animations are stored                                                                   |
 | autoFolderCreation | Boolean | true             | Automatically create the lottie folder if it doesn't exist. You can disable for client-only apps or manual folder management          |
 | enableLogs         | Boolean | true             | Enable terminal logs from the module during development. Disable if you like silence.                                       |
+| defaults           | Object  | {}               | Set default prop values for every `<Lottie>` instance project-wide. Any prop listed in the Props table can be used as a key. Per-instance props always take priority. |
+
+### Component Defaults
+
+Use `lottie.defaults` to avoid repeating the same props on every `<Lottie>` usage. Any prop from the table below can be set as a key. Individual instances can still override them.
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  lottie: {
+    defaults: {
+      loop: false,
+      autoplay: false,
+      renderer: 'canvas',
+    },
+  },
+})
+```
+
+```vue
+<!-- uses module defaults: loop=false, autoplay=false, renderer='canvas' -->
+<Lottie name="confetti" />
+
+<!-- overrides loop locally; other defaults still apply -->
+<Lottie name="confetti" :loop="3" />
+```
 
 ## `<Lottie>` Props: 
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,11 +9,30 @@ import {
 } from "@nuxt/kit";
 import { join } from "path";
 
+export interface LottieDefaults {
+  loop?: boolean | number;
+  autoplay?: boolean;
+  width?: number | string;
+  height?: number | string;
+  speed?: number;
+  delay?: number;
+  direction?: string;
+  pauseOnHover?: boolean;
+  playOnHover?: boolean;
+  backgroundColor?: string;
+  pauseAnimation?: boolean;
+  noMargin?: boolean;
+  scale?: number;
+  renderer?: string;
+  assetsPath?: string;
+}
+
 export interface ModuleOptions {
   componentName?: string;
   lottieFolder?: string;
   autoFolderCreation?: boolean;
   enableLogs?: boolean;
+  defaults?: LottieDefaults;
 }
 
 export type * from "./types";
@@ -113,6 +132,7 @@ export default defineNuxtModule<ModuleOptions>({
         export const animations = import.meta.glob('${lottieFolder}/**/*.json', { eager: true });
         export const folderPath = '${lottieFolder}';
         export const autoFolderCreation = ${shouldCreateFolder};
+        export const defaults = ${JSON.stringify(options.defaults ?? {})};
       `,
     });
 

--- a/src/runtime/Lottie.vue
+++ b/src/runtime/Lottie.vue
@@ -14,7 +14,10 @@ import {
   animations,
   folderPath,
   autoFolderCreation,
+  defaults,
 } from "#build/lottie-animations";
+
+const d = defaults as Record<string, any>;
 
 import type { PropType } from "vue";
 
@@ -45,59 +48,59 @@ const props = defineProps({
   },
   loop: {
     type: [Boolean, Number] as PropType<LottieProps["loop"]>,
-    default: true,
+    default: "loop" in d ? d.loop : true,
   },
   autoplay: {
     type: Boolean as PropType<LottieProps["autoplay"]>,
-    default: true,
+    default: "autoplay" in d ? d.autoplay : true,
   },
   width: {
     type: [Number, String] as PropType<LottieProps["width"]>,
-    default: "100%",
+    default: "width" in d ? d.width : "100%",
   },
   height: {
     type: [Number, String] as PropType<LottieProps["height"]>,
-    default: "100%",
+    default: "height" in d ? d.height : "100%",
   },
   speed: {
     type: Number as PropType<LottieProps["speed"]>,
-    default: 1,
+    default: "speed" in d ? d.speed : 1,
   },
   delay: {
     type: Number as PropType<LottieProps["delay"]>,
-    default: 0,
+    default: "delay" in d ? d.delay : 0,
   },
   direction: {
     type: String as PropType<LottieProps["direction"]>,
-    default: "forward",
+    default: "direction" in d ? d.direction : "forward",
   },
   pauseOnHover: {
     type: Boolean as PropType<LottieProps["pauseOnHover"]>,
-    default: false,
+    default: "pauseOnHover" in d ? d.pauseOnHover : false,
   },
   playOnHover: {
     type: Boolean as PropType<LottieProps["playOnHover"]>,
-    default: false,
+    default: "playOnHover" in d ? d.playOnHover : false,
   },
   backgroundColor: {
     type: String as PropType<LottieProps["backgroundColor"]>,
-    default: "transparent",
+    default: "backgroundColor" in d ? d.backgroundColor : "transparent",
   },
   pauseAnimation: {
     type: Boolean as PropType<LottieProps["pauseAnimation"]>,
-    default: false,
+    default: "pauseAnimation" in d ? d.pauseAnimation : false,
   },
   noMargin: {
     type: Boolean as PropType<LottieProps["noMargin"]>,
-    default: false,
+    default: "noMargin" in d ? d.noMargin : false,
   },
   scale: {
     type: Number as PropType<LottieProps["scale"]>,
-    default: 1,
+    default: "scale" in d ? d.scale : 1,
   },
   renderer: {
     type: String as PropType<LottieProps["renderer"]>,
-    default: "svg",
+    default: "renderer" in d ? d.renderer : "svg",
   },
   rendererSettings: {
     type: Object as PropType<LottieProps["rendererSettings"]>,
@@ -105,7 +108,7 @@ const props = defineProps({
   },
   assetsPath: {
     type: String as PropType<LottieProps["assetsPath"]>,
-    default: "",
+    default: "assetsPath" in d ? d.assetsPath : "",
   },
 });
 


### PR DESCRIPTION
## Summary

Adds a `defaults` option to the `lottie` module config in `nuxt.config.ts`, allowing project-wide default values for any `<Lottie>` prop. Individual usages can still override per-instance.

## How it works

The `defaults` object is serialised into the existing `#build/lottie-animations` virtual module at build time. `Lottie.vue` imports it and uses `"key" in defaults` checks to fall back to the hardcoded original defaults when a key is absent — zero runtime overhead, no breaking change.

## Usage

```ts
// nuxt.config.ts
export default defineNuxtConfig({
  lottie: {
    defaults: {
      loop: false,
      autoplay: false,
    },
  },
})
```

```vue
<!-- uses module defaults: loop=false, autoplay=false -->
<Lottie name="confetti" />

<!-- overrides locally -->
<Lottie name="confetti" :loop="true" :autoplay="true" />
```

Closes #19